### PR TITLE
Switched rollup external from object literal to array literal

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,11 +22,11 @@ export default {
 			terser()
 		]
 	}],
-	external: {
+	external: [
 		...require('module').builtinModules,
 		...Object.keys(pkg.dependencies || {}),
 		...Object.keys(pkg.peerDependencies || {}),
-	},
+	],
 	plugins: [
 		resolve(),
 		typescript({


### PR DESCRIPTION
Closes #2 

[Reference](https://rollupjs.org/guide/en/#external)